### PR TITLE
feat: add bulk email sending script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# 批量发送邮件脚本使用说明
+
+这个仓库提供了一个名为 `send_emails.py` 的 Python 脚本, 能够根据一份邮件模板和一份邮箱地址清单, 自动逐个发送邮件。脚本专为没有编程基础的用户设计, 只要准备好模板和收件人列表, 按照说明执行即可。
+
+## 1. 环境准备
+
+1. 在电脑上安装 [Python 3.8 及以上版本](https://www.python.org/downloads/)。
+2. 下载或复制本仓库的 `send_emails.py` 文件到本地目录。
+3. 打开终端(Windows 可使用“命令提示符”或 PowerShell, macOS/Linux 使用 Terminal)。
+
+## 2. 准备邮件模板
+
+新建一个普通的文本文件, 例如 `template.txt`, 内容格式如下:
+
+```
+Subject: 您好 {name}
+
+这是一封示例邮件。
+{name} 您好, 这是自动发送的内容。
+```
+
+* 第一行必须以 `Subject:` 开头, 后面是邮件主题。
+* 正文可以写多行文字。
+* 可以使用 `{name}` 这种占位符来插入收件人信息(下文会介绍如何提供)。
+
+## 3. 准备收件人清单
+
+使用 Excel 或者其他表格软件创建一个 CSV 文件, 例如 `recipients.csv`, 第一行是表头, 至少需要 `email` 这一列:
+
+```
+email,name
+alice@example.com,小红
+bob@example.com,小明
+```
+
+* `email` 列是必须的, 其他列(例如 `name`)可选。
+* 如果模板中使用了 `{name}` 占位符, 则在 CSV 中需要存在 `name` 这一列。
+* 保存文件时请选择“CSV UTF-8 (逗号分隔)”格式。
+
+## 4. 运行脚本
+
+在终端中切换到 `send_emails.py` 所在目录, 执行以下命令(请把示例参数替换成自己的信息):
+
+```
+python send_emails.py template.txt recipients.csv \
+    --sender your_email@example.com \
+    --smtp-host smtp.example.com \
+    --smtp-port 587 \
+    --smtp-user your_email@example.com
+```
+
+运行后程序会提示输入邮箱的登录密码或授权码(输入时不会显示)。
+
+常用参数说明:
+
+* `template.txt` / `recipients.csv` : 模板和收件人文件的路径。
+* `--sender` : 发件人邮箱地址, 会出现在邮件的 From 字段。
+* `--smtp-host` : 邮箱服务商提供的 SMTP 服务器地址(例如 QQ 邮箱是 `smtp.qq.com`)。
+* `--smtp-port` : SMTP 端口, 常见的有 587(默认, 需要 STARTTLS) 或 465(SSL)。
+* `--smtp-user` : 登录 SMTP 服务器的用户名, 通常就是邮箱地址。
+* `--use-ssl` : 如果你的邮箱服务商要求使用 SSL(常见于端口 465), 就在命令末尾加上该选项。
+* `--no-starttls` : 某些旧服务器不支持 STARTTLS, 可以加上这个选项关闭加密启动。
+* `--password` : 直接在命令中提供密码或授权码(不推荐, 为了安全请尽量手动输入)。
+* `--dry-run` : 只预览最终邮件内容, 不实际发送, 用于检查格式。
+
+## 5. 先做预览
+
+建议先执行一次预览, 确认主题和正文是否正确:
+
+```
+python send_emails.py template.txt recipients.csv \
+    --sender your_email@example.com \
+    --smtp-host smtp.example.com \
+    --smtp-port 587 \
+    --smtp-user your_email@example.com \
+    --dry-run
+```
+
+程序会在终端中显示每一封邮件的主题和正文, 但不会真正发送。
+
+## 6. 正式发送
+
+确认无误后, 去掉 `--dry-run` 重新运行命令, 按提示输入密码或授权码即可发送。发送过程中, 终端会显示每一个邮箱的发送状态。
+
+## 7. 常见问题
+
+* **SMTP 密码或授权码是什么?** 很多邮箱服务商不会使用你的登录密码, 而是需要到邮箱设置里生成一个“授权码”用于第三方客户端登录。
+* **如何获取 SMTP 服务器地址?** 可以在邮箱服务商的帮助中心搜索“SMTP 设置”, 常见邮箱如 QQ、163、Gmail 都会提供详细说明。
+* **发送失败怎么办?**
+  * 检查邮箱是否开启了 SMTP/IMAP 服务。
+  * 确认授权码是否正确。
+  * 有些服务商限制短时间内的发送数量, 需要等待一段时间或申请企业邮件服务。
+  * 如果报错提示缺少某个占位符, 请确认 CSV 文件里是否存在对应的列。
+
+按照以上步骤, 即便没有编程基础, 也可以顺利批量发送邮件。祝使用顺利!

--- a/send_emails.py
+++ b/send_emails.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Simple bulk email sender based on a text template and CSV recipient list.
+
+This script is designed for non-programmers.  Provide an email template text
+file and a CSV file containing your recipients and the script will send an
+individual email to each person.
+
+Example template file (template.txt)::
+
+    Subject: 您好 {name}
+
+    这是一封测试邮件, 内容可以写在这里。
+
+Example recipients file (recipients.csv)::
+
+    email,name
+    alice@example.com,小红
+    bob@example.com,小明
+
+Any column in the CSV file can be referenced from the template using
+``{column_name}`` placeholders.  The only required column is ``email``.
+
+To see how the message will look without actually sending anything, run the
+script with ``--dry-run``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import getpass
+import smtplib
+import ssl
+from dataclasses import dataclass
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+@dataclass
+class Template:
+    """Represents the loaded email template."""
+
+    subject: str
+    body: str
+
+
+class TemplateFormatError(ValueError):
+    """Raised when the template file is missing the required Subject line."""
+
+
+def load_template(path: Path) -> Template:
+    """Load the subject and body from the template text file."""
+
+    content = path.read_text(encoding="utf-8")
+    if not content.strip():
+        raise TemplateFormatError("模板文件是空的, 需要包含Subject行和正文内容。")
+
+    lines = content.splitlines()
+    subject_line = lines[0].strip()
+    prefix = "subject:"
+    if not subject_line.lower().startswith(prefix):
+        raise TemplateFormatError(
+            "模板文件的第一行必须以 'Subject:' 开头, 例如 'Subject: 您好'"
+        )
+
+    subject = subject_line[len(prefix) :].strip()
+    # Preserve blank lines between the subject and the body.
+    body_lines = lines[1:]
+    body = "\n".join(body_lines).lstrip("\n")
+    return Template(subject=subject, body=body)
+
+
+def load_recipients(path: Path) -> List[Dict[str, str]]:
+    """Read recipients from a CSV file and ensure the required columns exist."""
+
+    with path.open(newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        if reader.fieldnames is None:
+            raise ValueError("收件人清单需要包含表头, 例如: email,name")
+        if "email" not in reader.fieldnames:
+            raise ValueError("收件人清单必须包含名为 'email' 的列。")
+
+        recipients = []
+        for row_number, row in enumerate(reader, start=2):
+            email_address = (row.get("email") or "").strip()
+            if not email_address:
+                raise ValueError(f"第 {row_number} 行缺少 email 地址。")
+            recipients.append({key: (value or "").strip() for key, value in row.items()})
+
+    if not recipients:
+        raise ValueError("收件人清单为空, 请至少提供一个邮箱地址。")
+    return recipients
+
+
+def render(template: Template, recipient: Dict[str, str]) -> Tuple[str, str]:
+    """Fill placeholders in the template using recipient information."""
+
+    try:
+        subject = template.subject.format(**recipient)
+        body = template.body.format(**recipient)
+    except KeyError as exc:  # pragma: no cover - runtime guard
+        missing = exc.args[0]
+        raise KeyError(
+            f"模板中使用了 {{ {missing} }} 占位符, 但在收件人清单中找不到对应的列。"
+        ) from exc
+    return subject, body
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="根据模板和收件人清单发送批量邮件。",
+    )
+    parser.add_argument(
+        "template",
+        type=Path,
+        help="包含邮件主题和正文的模板文本文件。",
+    )
+    parser.add_argument(
+        "recipients",
+        type=Path,
+        help="包含收件人信息的CSV文件, 必须包含 email 列。",
+    )
+    parser.add_argument(
+        "--sender",
+        required=True,
+        help="发件人邮箱地址 (From)。",
+    )
+    parser.add_argument(
+        "--smtp-host",
+        required=True,
+        help="SMTP 服务器地址, 例如 smtp.qq.com。",
+    )
+    parser.add_argument(
+        "--smtp-port",
+        type=int,
+        default=587,
+        help="SMTP 服务器端口, 默认 587 (STARTTLS)。",
+    )
+    parser.add_argument(
+        "--smtp-user",
+        help="用于登录 SMTP 服务器的用户名, 默认与 --sender 相同。",
+    )
+    parser.add_argument(
+        "--password",
+        help="SMTP 登录密码或授权码。未提供时会安全地提示输入。",
+    )
+    parser.add_argument(
+        "--use-ssl",
+        action="store_true",
+        help="使用 SSL 方式连接 (通常用于端口 465)。",
+    )
+    parser.add_argument(
+        "--no-starttls",
+        action="store_true",
+        help="禁用 STARTTLS, 仅在服务器明确要求纯文本连接时使用。",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="仅显示生成的邮件内容, 不真正发送。",
+    )
+    return parser
+
+
+def connect_smtp(args: argparse.Namespace) -> smtplib.SMTP:
+    """Create the SMTP connection according to the provided arguments."""
+
+    if args.use_ssl:
+        server: smtplib.SMTP = smtplib.SMTP_SSL(args.smtp_host, args.smtp_port)
+        server.ehlo()
+        return server
+
+    server = smtplib.SMTP(args.smtp_host, args.smtp_port)
+    server.ehlo()
+    if not args.no_starttls:
+        server.starttls(context=ssl.create_default_context())
+        server.ehlo()
+    return server
+
+
+def send_email(
+    server: smtplib.SMTP,
+    sender: str,
+    recipient: Dict[str, str],
+    subject: str,
+    body: str,
+) -> None:
+    """Send a single email message using the provided SMTP server."""
+
+    message = EmailMessage()
+    message["From"] = sender
+    message["To"] = recipient["email"]
+    message["Subject"] = subject
+    message.set_content(body)
+    server.send_message(message)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    template = load_template(args.template)
+    recipients = load_recipients(args.recipients)
+
+    password = args.password
+    if password is None:
+        password = getpass.getpass("请输入 SMTP 登录密码或授权码: ")
+
+    smtp_user = args.smtp_user or args.sender
+
+    if args.dry_run:
+        print("[DRY RUN] 以下是将要发送的邮件预览:\n")
+        for recipient in recipients:
+            subject, body = render(template, recipient)
+            print(f"收件人: {recipient['email']}")
+            print(f"主题: {subject}")
+            print("正文:")
+            print(body)
+            print("-" * 40)
+        return 0
+
+    with connect_smtp(args) as server:
+        server.login(smtp_user, password)
+        for recipient in recipients:
+            subject, body = render(template, recipient)
+            send_email(server, args.sender, recipient, subject, body)
+            print(f"已发送给 {recipient['email']}")
+
+    print("全部邮件已发送完成。")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Python CLI script that loads an email template and CSV list to send personalized messages via SMTP
- document setup and usage steps for running the script without programming experience

## Testing
- python -m compileall send_emails.py

------
https://chatgpt.com/codex/tasks/task_e_68ccd05435788321a0e17a928f9396e8